### PR TITLE
fix: generate button style

### DIFF
--- a/src/script/dist/index.js
+++ b/src/script/dist/index.js
@@ -540,6 +540,7 @@
       const switchElement = document.createElement('button');
       switchElement.innerHTML = '开始生成骨架图';
       Object.assign(switchElement.style, {
+        position: 'relative',
         width: '100%',
         zIndex: 9999,
         color: '#FFFFFF',
@@ -698,8 +699,6 @@
           break;
         case 'A': // A label processing is placed behind to prevent IMG from displaying an exception
           aHandler(node);
-          break;
-        default:
           break;
       }
 

--- a/src/script/main.js
+++ b/src/script/main.js
@@ -38,6 +38,7 @@ window.AwesomeSkeleton = {
     const switchElement = document.createElement('button');
     switchElement.innerHTML = '开始生成骨架图';
     Object.assign(switchElement.style, {
+      position: 'relative',
       width: '100%',
       zIndex: 9999,
       color: '#FFFFFF',


### PR DESCRIPTION
Add "position" property for generate button to make "z-index" work

If page has a fixed header at top, we can not see and click the generate button because the property "z-index" do not work without "position"

![image](https://user-images.githubusercontent.com/27844879/84241622-4bffef00-ab32-11ea-834e-1be15ced8987.png)

![image](https://user-images.githubusercontent.com/27844879/84241487-1fe46e00-ab32-11ea-86fd-256f9118a544.png)
